### PR TITLE
Adding Manual Reclaim Stratedy

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "atom_box"
-version = "0.1.2"
+version = "0.1.3"
 edition = "2018"
 authors = ["John Bell <bell.john.andrew@gmail.com>"]
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Atom Box
 
 Atom Box provides an atomic box implementation where the box owns the contained value and its underlying allocation.
-It is therefore, responsible for deallocating the memory when it is no longer being access by any threads.
+It is therefore, responsible for deallocating the memory when it is no longer being accessed by any threads.
 
 Under the covers Atom Box is 'a safe implementation of hazard pointers in rust.'
 

--- a/src/domain/mod.rs
+++ b/src/domain/mod.rs
@@ -161,6 +161,26 @@ On nightly this will panic if the domain id is equal to the shared domain's id (
         )
     }
 
+    /// Reclaim all unprotected retired items.
+    ///
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use atom_box::{AtomBox, domain::{Domain, ReclaimStrategy}};
+    ///
+    /// const CUSTOM_DOMAIN_ID: usize = 42;
+    /// static CUSTOM_DOMAIN: Domain<CUSTOM_DOMAIN_ID> = Domain::new(ReclaimStrategy::Manual);
+    ///
+    /// let atom_box = AtomBox::new_with_domain("Hello World", &CUSTOM_DOMAIN);
+    /// atom_box.swap("Goodbye World");
+    ///
+    /// CUSTOM_DOMAIN.reclaim();
+    /// ```
+    pub fn reclaim(&self) -> usize {
+        self.bulk_reclaim()
+    }
+
     fn bulk_reclaim(&self) -> usize {
         let retired_list = self
             .retired

--- a/src/domain/reclaim_strategy.rs
+++ b/src/domain/reclaim_strategy.rs
@@ -11,6 +11,7 @@ const DEFAULT_HAZARD_POINTER_MULTIPLIER: isize = 2;
 /// A `default` const constructor function is defined for this enum. It cannot implement `Default`
 /// since we would like the `default` constructor to be a const function.
 #[derive(Debug)]
+#[non_exhaustive]
 pub enum ReclaimStrategy {
     /// Every time an item is retired the domain will try to reclaim any items which are not
     /// currently being protected by a hazard pointer.
@@ -19,6 +20,9 @@ pub enum ReclaimStrategy {
     /// Items will be reclaimed both periodically, and when the number of retired items exceeds
     /// certain thresholds.
     TimedCapped(TimedCappedSettings),
+
+    /// Memory reclaimation will only happen when the `reclaim` method on [`crate::domain::Domain`]
+    Manual,
 }
 
 impl ReclaimStrategy {
@@ -27,7 +31,8 @@ impl ReclaimStrategy {
             Self::Eager => true,
             Self::TimedCapped(settings) => {
                 settings.should_reclaim(hazard_pointer_count, retired_count)
-            }
+            },
+            Self::Manual => false,
         }
     }
 

--- a/src/domain/reclaim_strategy.rs
+++ b/src/domain/reclaim_strategy.rs
@@ -22,6 +22,7 @@ pub enum ReclaimStrategy {
     TimedCapped(TimedCappedSettings),
 
     /// Memory reclaimation will only happen when the `reclaim` method on [`crate::domain::Domain`]
+    /// is called.
     Manual,
 }
 

--- a/src/domain/reclaim_strategy.rs
+++ b/src/domain/reclaim_strategy.rs
@@ -31,7 +31,7 @@ impl ReclaimStrategy {
             Self::Eager => true,
             Self::TimedCapped(settings) => {
                 settings.should_reclaim(hazard_pointer_count, retired_count)
-            },
+            }
             Self::Manual => false,
         }
     }


### PR DESCRIPTION
Adding a manual reclaim strategy.
 
- Adding a new reclaim strategy
- Making reclaim strategy non exhaustive to avoid changes like this becoming breaking changes
- Exposing a public reclaim method on Domain to enable manual reclamation.