### PR TITLE
Remove object lifetime cast

### DIFF
--- a/src/domain/mod.rs
+++ b/src/domain/mod.rs
@@ -98,7 +98,11 @@ impl Retire {
     fn new<T>(ptr: *mut T) -> Self {
         Self {
             ptr: ptr as *mut usize,
-            retirable: ptr as *mut dyn Retirable,
+            retirable: unsafe {
+                core::mem::transmute::<*mut (dyn Retirable + '_), *mut (dyn Retirable + 'static)>(
+                    ptr,
+                )
+            },
         }
     }
 }


### PR DESCRIPTION
There is an ongoing effort to remove lifetime casts on trait objects from the language. Please see: https://github.com/rust-lang/rust/pull/136776

Using a transmute to perform the relevant pointer cast is the recommended replacement.